### PR TITLE
Add Azure Monitor maturity dashboard example

### DIFF
--- a/maturity-dashboard/README.md
+++ b/maturity-dashboard/README.md
@@ -1,0 +1,32 @@
+# Azure Monitor Maturity Dashboard
+
+This example shows a minimal Express application that queries Azure Monitor logs and maps them to a simple maturity assessment. It exposes a small website that allows selecting an industry so that different framework requirements can be applied.
+
+This code only demonstrates the flow. You must provide Azure credentials via environment variables and install the required dependencies before running.
+
+## Setup
+
+```bash
+cd maturity-dashboard
+npm install
+```
+
+Create a `.env` file or set the following environment variables for Azure authentication:
+
+- `AZURE_TENANT_ID`
+- `AZURE_CLIENT_ID`
+- `AZURE_CLIENT_SECRET`
+- `AZURE_SUBSCRIPTION_ID`
+- `AZURE_RESOURCE_GROUP`
+
+Run the server:
+
+```bash
+node index.js
+```
+
+Open [http://localhost:3000](http://localhost:3000) in your browser.
+
+## Industry frameworks
+
+Framework requirements are stored in `frameworks.json`. Update this file to adjust the logic for different industries.

--- a/maturity-dashboard/frameworks.json
+++ b/maturity-dashboard/frameworks.json
@@ -1,0 +1,14 @@
+{
+  "finance": {
+    "bestPractices": "UK FCA guidelines and ISO 27001 controls",
+    "threshold": 80
+  },
+  "healthcare": {
+    "bestPractices": "UK NHS Digital security framework",
+    "threshold": 85
+  },
+  "technology": {
+    "bestPractices": "NCSC cloud security principles",
+    "threshold": 75
+  }
+}

--- a/maturity-dashboard/index.js
+++ b/maturity-dashboard/index.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const { DefaultAzureCredential } = require('@azure/identity');
+const { LogsQueryClient } = require('@azure/monitor-query');
+require('dotenv').config();
+
+const app = express();
+const port = process.env.PORT || 3000;
+const credential = new DefaultAzureCredential();
+const logsClient = new LogsQueryClient(credential);
+
+const frameworksPath = path.join(__dirname, 'frameworks.json');
+let frameworks = {};
+if (fs.existsSync(frameworksPath)) {
+  frameworks = JSON.parse(fs.readFileSync(frameworksPath));
+}
+
+app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.json());
+
+app.post('/api/maturity', async (req, res) => {
+  const { industry } = req.body;
+  const framework = frameworks[industry];
+  if (!framework) {
+    return res.status(400).json({ error: 'Unknown industry' });
+  }
+
+  try {
+    const query = 'AzureActivity | limit 100';
+    const result = await logsClient.queryWorkspace(
+      process.env.AZURE_WORKSPACE_ID,
+      query,
+      { timespan: 'P1D' }
+    );
+
+    const score = Math.min(100, result.tables[0].rows.length);
+    const maturity = score >= framework.threshold ? 'Compliant' : 'Needs Improvement';
+    res.json({
+      industry,
+      bestPractices: framework.bestPractices,
+      score,
+      maturity
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to query logs' });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Dashboard listening on port ${port}`);
+});

--- a/maturity-dashboard/package.json
+++ b/maturity-dashboard/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "azure-maturity-dashboard",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "dotenv": "^16.0.3",
+    "@azure/identity": "^3.3.0",
+    "@azure/monitor-query": "^1.2.1"
+  }
+}

--- a/maturity-dashboard/public/index.html
+++ b/maturity-dashboard/public/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Azure Maturity Dashboard</title>
+</head>
+<body>
+  <h1>Azure Maturity Dashboard</h1>
+  <label for="industry">Select Industry:</label>
+  <select id="industry">
+    <option value="finance">Finance</option>
+    <option value="healthcare">Healthcare</option>
+    <option value="technology">Technology</option>
+  </select>
+  <button id="check">Check Maturity</button>
+  <pre id="result"></pre>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/maturity-dashboard/public/script.js
+++ b/maturity-dashboard/public/script.js
@@ -1,0 +1,12 @@
+async function checkMaturity() {
+  const industry = document.getElementById('industry').value;
+  const res = await fetch('/api/maturity', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ industry })
+  });
+  const data = await res.json();
+  document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+}
+
+document.getElementById('check').addEventListener('click', checkMaturity);


### PR DESCRIPTION
## Summary
- show an Express-based dashboard that queries Azure Monitor logs
- allow selecting an industry which influences the maturity score
- document setup and framework configuration

## Testing
- `npm test` *(fails: `jasmine: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68555fb986f48322990ef45df8a9c568