### PR TITLE
Fix RSI calculation for flat periods

### DIFF
--- a/lib/rsi.js
+++ b/lib/rsi.js
@@ -31,9 +31,15 @@ module.exports = function rsi (s, key, length) {
       s.period[key + '_avg_loss'] = ((avg_loss * (length - 1)) + (current_loss > 0 ? current_loss : 0)) / length
     }
 
-    if(s.period[key + '_avg_loss'] == 0) {
+    if (s.period[key + '_avg_gain'] === 0 && s.period[key + '_avg_loss'] === 0) {
+      // no movement during the period, RSI should be neutral
+      s.period[key] = 50
+    }
+    else if (s.period[key + '_avg_loss'] === 0) {
+      // only gains, no losses
       s.period[key] = 100
-    } else {
+    }
+    else {
       var rs = s.period[key + '_avg_gain'] / s.period[key + '_avg_loss']
       s.period[key] = precisionRound(100 - (100 / (1 + rs)), 2)
     }

--- a/test/lib/rsi.test.js
+++ b/test/lib/rsi.test.js
@@ -20,10 +20,10 @@ describe('RSI (Relative Strength Index)', function () {
     expect(noGainData.period.rsi).toEqual(0)
   })
 
-  it('should set RSI to 0 when there is no price change for the entire period', function() {
+  it('should set RSI to 50 when there is no price change for the entire period', function() {
     RSI(noPriceChangeData, 'rsi', 14)
 
-    expect(noPriceChangeData.period.rsi).toEqual(100)
+    expect(noPriceChangeData.period.rsi).toEqual(50)
   })
 })
 


### PR DESCRIPTION
## Summary
- handle case with no gains and losses in RSI
- expect neutral RSI value in flat-price test

## Testing
- `npm test` *(fails: `jasmine: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68554525446c8322a929988f6d6557a9